### PR TITLE
BUGFIX: Improve stability slightly and fix tests

### DIFF
--- a/Classes/Domain/Model/TaskExecution.php
+++ b/Classes/Domain/Model/TaskExecution.php
@@ -110,7 +110,7 @@ class TaskExecution
     }
 
     /**
-     * @return Workload
+     * @return Workload|null
      */
     public function getWorkload(): ?Workload
     {
@@ -142,7 +142,7 @@ class TaskExecution
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getEndTime(): ?\DateTime
     {
@@ -150,7 +150,7 @@ class TaskExecution
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getDuration(): ?float
     {
@@ -158,7 +158,7 @@ class TaskExecution
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getResult(): ?string
     {
@@ -170,7 +170,7 @@ class TaskExecution
      */
     public function getException(): string
     {
-        return (string)$this->exception;
+        return $this->exception;
     }
 
     /**

--- a/Classes/Domain/Repository/TaskExecutionRepository.php
+++ b/Classes/Domain/Repository/TaskExecutionRepository.php
@@ -6,11 +6,13 @@ namespace Flowpack\Task\Domain\Repository;
 use DateTime;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\ORMException;
 use Flowpack\Task\Domain\Model\TaskExecution;
 use Neos\Flow\Annotations as Flow;
 use Flowpack\Task\Domain\Task\Task;
 use Flowpack\Task\Domain\Task\TaskStatus;
 use Neos\Flow\Persistence\Doctrine\Repository;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\QueryInterface;
 use Neos\Flow\Persistence\QueryResultInterface;
 
@@ -54,7 +56,11 @@ class TaskExecutionRepository extends Repository
         );
 
         foreach ($query->execute() as $scheduledTask) {
-            $this->remove($scheduledTask);
+            try {
+                $this->remove($scheduledTask);
+            } catch (ORMException|IllegalObjectTypeException $e) {
+                throw new \RuntimeException('Failed to remove task from execution repository', 1645610863, $e);
+            }
         }
     }
 

--- a/Classes/Domain/Task/TaskCollection.php
+++ b/Classes/Domain/Task/TaskCollection.php
@@ -7,14 +7,18 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 class TaskCollection extends ArrayCollection
 {
-    public function getTask(string $taskIdentifier): Task
+    public function getTask(string $taskIdentifier): TaskInterface
     {
-        return $this->get($taskIdentifier);
+        $task = $this->get($taskIdentifier);
+        if ($task === null) {
+            throw new \InvalidArgumentException(sprintf('Task "%s" does not exist in this collection', $taskIdentifier), 1645610446);
+        }
+        return $task;
     }
 
     public function filterEndBeforeNow(): ArrayCollection
     {
-        return $this->filter(static function (Task $task, $taskIdentifier) {
+        return $this->filter(static function (Task $task) {
             return $task->getLastExecution() === null || $task->getLastExecution() > new \DateTime();
         });
     }

--- a/Tests/Functional/Domain/Repository/TaskExecutionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TaskExecutionRepositoryTest.php
@@ -40,13 +40,11 @@ class TaskExecutionRepositoryTest extends FunctionalTestCase
             [
                 'taskOne' => [
                     'handlerClass' => TestHandler::class,
-                    'cronExpression' => '5 * * * *',
-
+                    'cronExpression' => '* * * * *',
                 ],
                 'taskTwo' => [
                     'handlerClass' => TestHandler::class,
-                    'cronExpression' => '* * * * *',
-
+                    'cronExpression' => '5 * * * *',
                 ],
                 'taskThree' => [
                     'handlerClass' => TestHandler::class,


### PR DESCRIPTION
This change mostly tweaks some cosmetics, fixes a broken functional test
and improves the UX of the commands a bit:

* Prevent null pointer exceptions in `TaskCommandController` and provide
  error message if a given task id does not exist
* Fix `TaskRunner::reFetchExecution()` that had no effect previously
* Fix type hints
* Fix `Flowpack\Task\Tests\Functional\Domain\Repository\TaskExecutionRepositoryTest::findNext`
  that is broken since version 0.1.0

Fixes: #5