### PR TITLE
TASK: TaskExecutionHistory removes non existing task handlers

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,3 +4,4 @@ Flowpack:
     lockStorage: 'flock://%FLOW_PATH_TEMPORARY%/SymfonyLockStorage'
     tasks: []
     keepTaskExecutionHistory: 3
+    keepRemovedTasksInTaskExecutionHistory: true


### PR DESCRIPTION
During `TaskExecutionHistory::cleanup()` DB entries are removed if the task handlers in the DB is not configured or doesn't exist anymore.  
This behaviour can be configured by the setting `keepRemovedTasksInTaskExecutionHistory` which by default keeps the current behaviour and doesn't remove entries.

This PR is about auto cleanup of the TaskExecutionHistory if one removes a task from the configuration or a handlerClass is renamed. Old entries are then automatically removed if enabled.