### PR TITLE
BUGFIX: Prevent permanent lock

### DIFF
--- a/Classes/Domain/Runner/PendingExecutionFinder.php
+++ b/Classes/Domain/Runner/PendingExecutionFinder.php
@@ -55,7 +55,7 @@ class PendingExecutionFinder
 
             $lock = $lockFactory->createLock($handler->getLockIdentifier($execution->getWorkload()));
 
-            if ($lock->acquire()) {
+            if (!$lock->acquire()) {
                 $skippedExecutions[] = $execution;
                 $this->logger->warning(sprintf('Execution "%s" is locked and skipped.', $execution->getTaskIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
                 continue;


### PR DESCRIPTION
Without this change:
all tasks will be locked and skipped from running, as soon as you configure a lock storage and implement the LockingTaskHandlerInterface

With this change:
The return value is handled as intended/expected when a lock is acquired (symfony/lock acquire returns true upon successfull lock aquire, false upon lock conflict)