### PR TITLE
fix: make serialization of workload work again

### DIFF
--- a/Classes/Domain/Model/TaskExecution.php
+++ b/Classes/Domain/Model/TaskExecution.php
@@ -5,7 +5,7 @@ namespace Flowpack\Task\Domain\Model;
 
 use Flowpack\Task\Domain\Task\Task;
 use Flowpack\Task\Domain\Task\TaskStatus;
-use Flowpack\Task\Domain\Task\Workload;
+use Flowpack\Task\Domain\Task\WorkloadInterface;
 use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -21,7 +21,7 @@ class TaskExecution
 
     /**
      * @ORM\Column(name="workload", type="object")
-     * @var Workload
+     * @var WorkloadInterface
      */
     protected $workload;
 
@@ -110,9 +110,9 @@ class TaskExecution
     }
 
     /**
-     * @return Workload|null
+     * @return WorkloadInterface|null
      */
-    public function getWorkload(): ?Workload
+    public function getWorkload(): ?WorkloadInterface
     {
         return $this->workload;
     }

--- a/Classes/Domain/Task/TaskCollectionFactory.php
+++ b/Classes/Domain/Task/TaskCollectionFactory.php
@@ -20,8 +20,11 @@ class TaskCollectionFactory
 
     protected ?TaskCollection $taskCollection = null;
 
-    public function __construct(private ObjectManagerInterface $objectManager)
+    private ObjectManagerInterface $objectManager;
+
+    public function __construct(ObjectManagerInterface $objectManager)
     {
+        $this->objectManager = $objectManager;
     }
 
     public function buildTasksFromConfiguration(): TaskCollection

--- a/Classes/Domain/Task/TaskCollectionFactory.php
+++ b/Classes/Domain/Task/TaskCollectionFactory.php
@@ -5,6 +5,7 @@ namespace Flowpack\Task\Domain\Task;
 
 use Cron\CronExpression;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
  * @Flow\Scope("singleton")
@@ -18,6 +19,10 @@ class TaskCollectionFactory
     protected array $taskConfigurations = [];
 
     protected ?TaskCollection $taskCollection = null;
+
+    public function __construct(private ObjectManagerInterface $objectManager)
+    {
+    }
 
     public function buildTasksFromConfiguration(): TaskCollection
     {
@@ -38,7 +43,7 @@ class TaskCollectionFactory
                 $taskConfiguration['handlerClass'],
                 $taskConfiguration['label'] ?? $taskIdentifier,
                 $taskConfiguration['description'] ?? '',
-                new Workload($taskConfiguration['workload'] ?? []),
+                $this->objectManager->get(WorkloadInterface::class, $taskConfiguration['workload'] ?? []),
                 new \DateTime($taskConfiguration['firstExecution'] ?? 'now'),
                 ($taskConfiguration['lastExecution'] ?? null) === null ? null : new \DateTime($taskConfiguration['lastExecution'])
             ));

--- a/Classes/Domain/Task/Workload.php
+++ b/Classes/Domain/Task/Workload.php
@@ -19,4 +19,14 @@ class Workload implements WorkloadInterface
     {
         return $this->data;
     }
+
+    public function __serialize(): array
+    {
+        return ['data' => $this->data];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->data = $data['data'];
+    }
 }


### PR DESCRIPTION
- Fix overwriting WorkloadInterface via object configuration by using objectManger for creating Workload object in TaskCollectionFactory
- fix serialization of workload by adding `__seralize()` and `__unserialize()` methods

#20 